### PR TITLE
Prevent BadRequestException on almost every upload

### DIFF
--- a/src/main/kotlin/pl/edu/uj/ii/ksi/mordor/controllers/FileUploadController.kt
+++ b/src/main/kotlin/pl/edu/uj/ii/ksi/mordor/controllers/FileUploadController.kt
@@ -67,7 +67,7 @@ class FileUploadController(
             val repository = fileUploadSessionService.getRepositoryServiceOfSession(session)
             for (file in model.files) {
                 val mountPath = if (model.mountPath == "/") { "." } else { model.mountPath }
-                if (!repository.fileExists(mountPath)) {
+                if (!repositoryService.fileExists(mountPath)) {
                     throw BadRequestException("No directory at chosen path")
                 }
                 repository.saveFile("$mountPath/${file.originalFilename}", file.inputStream)


### PR DESCRIPTION
Assuming this `if` prevents new folder creation:

- Every value of `mountPath`, other than `.` would cause `BadRequestException`.

- This happens, because `RepositoryService` is asked if some folder exists in brand new, empty `UploadSession`

- Prevented that by using `RepositoryService` of whole repository, not the ` RepositoryService` of some specific `UploadSession`